### PR TITLE
Fix playlist load on non-music pages

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -8,10 +8,17 @@
             try {
                 const response = await fetch('music/playlist.json');
                 playlist = await response.json();
-                showTrack(currentTrack);
+                if (audioPlayer) {
+                    showTrack(currentTrack);
+                } else if (playlist.length) {
+                    document.getElementById('floatingText').textContent = `♪ ${playlist[currentTrack].name}`;
+                }
             } catch (error) {
-                document.getElementById('trackName').textContent = 'playlist error';
-                document.getElementById('trackArtist').textContent = '';
+                if (document.getElementById('trackName')) {
+                    document.getElementById('trackName').textContent = 'playlist error';
+                    document.getElementById('trackArtist').textContent = '';
+                }
+                document.getElementById('floatingText').textContent = 'playlist error';
             }
         }
 
@@ -121,8 +128,8 @@
 
         // Initialize
 document.addEventListener('DOMContentLoaded', async function() {
+    await loadPlaylist();
     if (audioPlayer) {
-        await loadPlaylist();
         const volume = document.getElementById('volumeSlider');
         if (volume) {
             volume.addEventListener('input', function() {


### PR DESCRIPTION
## Summary
- load playlist even when `audioPlayer` element is not present
- show the current track in the floating music indicator if there's no player

## Testing
- `node -c js/main.js`
- `npm start` *(briefly started and stopped)*

------
https://chatgpt.com/codex/tasks/task_e_688be622955883208cef9a14a67d9d55