### PR TITLE
Persist music playback and fix volume control

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
         </div>
         <div class="floating-text" id="floatingText">loading...</div>
     </div>
+    <audio id="audioPlayer" preload="metadata" style="display:none"></audio>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,156 +1,219 @@
-        // Local music player logic
-        let playlist = [];
-        let currentTrack = 0;
-        let isPlaying = false;
-        let audioPlayer = document.getElementById('audioPlayer');
+// Local music player logic
+let playlist = [];
+let currentTrack = 0;
+let isPlaying = false;
+const audioPlayer = document.getElementById('audioPlayer');
+let initialState = {};
 
-        async function loadPlaylist() {
-            try {
-                const response = await fetch('music/playlist.json');
-                playlist = await response.json();
-                if (audioPlayer) {
-                    showTrack(currentTrack);
-                } else if (playlist.length) {
-                    document.getElementById('floatingText').textContent = `♪ ${playlist[currentTrack].name}`;
-                }
-            } catch (error) {
-                if (document.getElementById('trackName')) {
-                    document.getElementById('trackName').textContent = 'playlist error';
-                    document.getElementById('trackArtist').textContent = '';
-                }
-                document.getElementById('floatingText').textContent = 'playlist error';
-            }
+async function loadPlaylist() {
+    try {
+        const response = await fetch('music/playlist.json');
+        playlist = await response.json();
+    } catch (error) {
+        if (document.getElementById('trackName')) {
+            document.getElementById('trackName').textContent = 'playlist error';
+            document.getElementById('trackArtist').textContent = '';
         }
+        const floatText = document.getElementById('floatingText');
+        if (floatText) floatText.textContent = 'playlist error';
+    }
+}
 
-        function showTrack(index) {
-            if (!playlist.length) return;
-            const track = playlist[index];
-            document.getElementById('trackName').textContent = track.name;
-            document.getElementById('trackArtist').textContent = track.artist;
-            document.getElementById('albumArtContainer').innerHTML = track.albumArt
-                ? `<img src="${track.albumArt}" class="album-art" alt="Album Art">`
-                : '🎵';
-            audioPlayer.src = track.file;
-            audioPlayer.load();
-            document.getElementById('playBtn').textContent = '▶';
-            isPlaying = false;
-            document.querySelector('.music-player').classList.remove('playing');
-            document.getElementById('duration').textContent = '0:00';
-            document.getElementById('currentTime').textContent = '0:00';
-            document.getElementById('progress').style.width = '0%';
-            document.getElementById('floatingText').textContent = `♪ ${track.name}`;
+function restoreState() {
+    try {
+        initialState = JSON.parse(localStorage.getItem('playerState')) || {};
+    } catch (e) {
+        initialState = {};
+    }
+    if (initialState.track !== undefined && playlist.length) {
+        currentTrack = initialState.track % playlist.length;
+    }
+    if (audioPlayer) {
+        if (initialState.volume !== undefined) {
+            audioPlayer.volume = initialState.volume;
         }
-
-        function nextTrack(autoPlay = false) {
-            const shouldPlay = isPlaying || autoPlay;
-            currentTrack = (currentTrack + 1) % playlist.length;
-            showTrack(currentTrack);
-            if (shouldPlay) playTrack();
+        const volEl = document.getElementById('volumeSlider');
+        if (volEl) {
+            volEl.value = audioPlayer.volume;
         }
+    }
+    return initialState;
+}
 
-        function previousTrack() {
-            const shouldPlay = isPlaying;
-            currentTrack = (currentTrack - 1 + playlist.length) % playlist.length;
-            showTrack(currentTrack);
-            if (shouldPlay) playTrack();
+function saveState() {
+    if (!audioPlayer) return;
+    localStorage.setItem('playerState', JSON.stringify({
+        track: currentTrack,
+        time: audioPlayer.currentTime,
+        volume: audioPlayer.volume,
+        isPlaying: isPlaying
+    }));
+}
+
+function showTrack(index) {
+    if (!playlist.length) return;
+    const track = playlist[index];
+    const nameEl = document.getElementById('trackName');
+    const artistEl = document.getElementById('trackArtist');
+    const artEl = document.getElementById('albumArtContainer');
+    if (nameEl) nameEl.textContent = track.name;
+    if (artistEl) artistEl.textContent = track.artist;
+    if (artEl) {
+        artEl.innerHTML = track.albumArt
+            ? `<img src="${track.albumArt}" class="album-art" alt="Album Art">`
+            : '🎵';
+    }
+    if (audioPlayer) {
+        audioPlayer.src = track.file;
+        audioPlayer.load();
+    }
+    const playBtn = document.getElementById('playBtn');
+    if (playBtn) playBtn.textContent = '▶';
+    isPlaying = false;
+    const playerEl = document.querySelector('.music-player');
+    if (playerEl) playerEl.classList.remove('playing');
+    const durEl = document.getElementById('duration');
+    const curEl = document.getElementById('currentTime');
+    if (durEl) durEl.textContent = '0:00';
+    if (curEl) curEl.textContent = '0:00';
+    const progEl = document.getElementById('progress');
+    if (progEl) progEl.style.width = '0%';
+    const floatText = document.getElementById('floatingText');
+    if (floatText) floatText.textContent = `♪ ${track.name}`;
+}
+
+function nextTrack(autoPlay = true) {
+    const shouldPlay = isPlaying || autoPlay;
+    currentTrack = (currentTrack + 1) % playlist.length;
+    showTrack(currentTrack);
+    if (shouldPlay) playTrack();
+    saveState();
+}
+
+function previousTrack(autoPlay = true) {
+    const shouldPlay = isPlaying || autoPlay;
+    currentTrack = (currentTrack - 1 + playlist.length) % playlist.length;
+    showTrack(currentTrack);
+    if (shouldPlay) playTrack();
+    saveState();
+}
+
+function formatTime(seconds) {
+    seconds = Math.floor(seconds);
+    const min = Math.floor(seconds / 60);
+    const sec = seconds % 60;
+    return min + ':' + (sec < 10 ? '0' : '') + sec;
+}
+
+function playTrack() {
+    audioPlayer.play();
+    isPlaying = true;
+    const playBtn = document.getElementById('playBtn');
+    if (playBtn) playBtn.textContent = '⏸';
+    const playerEl = document.querySelector('.music-player');
+    if (playerEl) playerEl.classList.add('playing');
+    saveState();
+}
+
+function pauseTrack() {
+    audioPlayer.pause();
+    isPlaying = false;
+    const playBtn = document.getElementById('playBtn');
+    if (playBtn) playBtn.textContent = '▶';
+    const playerEl = document.querySelector('.music-player');
+    if (playerEl) playerEl.classList.remove('playing');
+    saveState();
+}
+
+function togglePlay() {
+    if (!audioPlayer || !audioPlayer.src) return;
+    if (isPlaying) {
+        pauseTrack();
+    } else {
+        playTrack();
+    }
+}
+
+function startProgressAnimation() {
+    function updateProgress() {
+        if (!isPlaying || audioPlayer.paused) return;
+        const currentTime = audioPlayer.currentTime;
+        const duration = audioPlayer.duration;
+        if (duration && !isNaN(duration)) {
+            const progressPercent = (currentTime / duration) * 100;
+            const progEl = document.getElementById('progress');
+            const curEl = document.getElementById('currentTime');
+            const durEl = document.getElementById('duration');
+            if (progEl) progEl.style.width = progressPercent + '%';
+            if (curEl) curEl.textContent = formatTime(currentTime);
+            if (durEl) durEl.textContent = formatTime(duration);
         }
+        requestAnimationFrame(updateProgress);
+    }
+    requestAnimationFrame(updateProgress);
+}
 
-        function formatTime(seconds) {
-            seconds = Math.floor(seconds);
-            const min = Math.floor(seconds / 60);
-            const sec = seconds % 60;
-            return min + ':' + (sec < 10 ? '0' : '') + sec;
-        }
+function seekTo(event) {
+    if (!audioPlayer || !audioPlayer.src || !audioPlayer.duration) return;
+    const progressBar = event.currentTarget;
+    const clickX = event.offsetX;
+    const width = progressBar.offsetWidth;
+    const percentage = clickX / width;
+    audioPlayer.currentTime = percentage * audioPlayer.duration;
+    saveState();
+}
 
-        function playTrack() {
-            audioPlayer.play();
-            isPlaying = true;
-            document.getElementById('playBtn').textContent = '⏸';
-            document.querySelector('.music-player').classList.add('playing');
-        }
+if (audioPlayer) {
+    audioPlayer.addEventListener('play', startProgressAnimation);
+    audioPlayer.addEventListener('ended', function () { nextTrack(true); });
+    audioPlayer.addEventListener('timeupdate', saveState);
+    audioPlayer.addEventListener('play', saveState);
+    audioPlayer.addEventListener('pause', saveState);
+}
+window.addEventListener('beforeunload', saveState);
 
-        function pauseTrack() {
-            audioPlayer.pause();
-            isPlaying = false;
-            document.getElementById('playBtn').textContent = '▶';
-            document.querySelector('.music-player').classList.remove('playing');
-        }
+// Project links
+function openProject(projectId) {
+    const projectUrls = {
+        'project1': 'https://github.com/chasemarshall/minimal-ui-kit',
+        'project2': 'https://github.com/chasemarshall/dotfiles',
+        'project3': 'https://github.com/chasemarshall/markdown-blog-engine',
+        'project4': 'https://github.com/chasemarshall/color-palette-generator'
+    };
+    window.open(projectUrls[projectId], '_blank');
+}
 
-        function togglePlay() {
-            if (!audioPlayer.src) return;
-            if (isPlaying) {
-                pauseTrack();
-            } else {
-                playTrack();
-            }
-        }
-
-        function startProgressAnimation() {
-            function updateProgress() {
-                if (!isPlaying || audioPlayer.paused) return;
-                const currentTime = audioPlayer.currentTime;
-                const duration = audioPlayer.duration;
-                if (duration && !isNaN(duration)) {
-                    const progressPercent = (currentTime / duration) * 100;
-                    document.getElementById('progress').style.width = progressPercent + '%';
-                    document.getElementById('currentTime').textContent = formatTime(currentTime);
-                    document.getElementById('duration').textContent = formatTime(duration);
-                }
-                requestAnimationFrame(updateProgress);
-            }
-            requestAnimationFrame(updateProgress);
-        }
-
-        function seekTo(event) {
-            if (!audioPlayer.src || !audioPlayer.duration) return;
-            const progressBar = event.currentTarget;
-            const clickX = event.offsetX;
-            const width = progressBar.offsetWidth;
-            const percentage = clickX / width;
-            audioPlayer.currentTime = percentage * audioPlayer.duration;
-        }
-
-        audioPlayer.addEventListener('play', startProgressAnimation);
-        audioPlayer.addEventListener('ended', function() {
-            nextTrack(true);
-        });
-
-        // Project links
-        function openProject(projectId) {
-            const projectUrls = {
-                'project1': 'https://github.com/chasemarshall/minimal-ui-kit',
-                'project2': 'https://github.com/chasemarshall/dotfiles',
-                'project3': 'https://github.com/chasemarshall/markdown-blog-engine',
-                'project4': 'https://github.com/chasemarshall/color-palette-generator'
-            };
-            window.open(projectUrls[projectId], '_blank');
-        }
-
-        // Initialize
-document.addEventListener('DOMContentLoaded', async function() {
+// Initialize
+document.addEventListener('DOMContentLoaded', async function () {
     await loadPlaylist();
+    restoreState();
+    showTrack(currentTrack);
     if (audioPlayer) {
         const volume = document.getElementById('volumeSlider');
         if (volume) {
-            volume.addEventListener('input', function() {
-                audioPlayer.volume = this.value;
+            volume.addEventListener('input', function () {
+                audioPlayer.volume = parseFloat(this.value);
+                saveState();
             });
-            audioPlayer.volume = volume.value;
         }
-        playTrack();
+        audioPlayer.addEventListener('loadedmetadata', function () {
+            audioPlayer.currentTime = initialState.time || 0;
+            if (initialState.isPlaying !== false) {
+                playTrack();
+            }
+        }, { once: true });
     }
-    // Simulate typing effect for the title
-            const title = document.querySelector('h1');
-            const originalText = title.textContent;
-            title.textContent = '';
-            let i = 0;
-            const typeWriter = setInterval(() => {
-                if (i < originalText.length) {
-                    title.textContent += originalText.charAt(i);
-                    i++;
-                } else {
-                    clearInterval(typeWriter);
-                }
-            }, 100);
-        });
+    const title = document.querySelector('h1');
+    const originalText = title.textContent;
+    title.textContent = '';
+    let i = 0;
+    const typeWriter = setInterval(() => {
+        if (i < originalText.length) {
+            title.textContent += originalText.charAt(i);
+            i++;
+        } else {
+            clearInterval(typeWriter);
+        }
+    }, 100);
+});
 

--- a/work.html
+++ b/work.html
@@ -54,6 +54,16 @@
             </section>
         </main>
     </div>
+    <div class="floating-music" onclick="window.location.href='music.html'" id="floatingMusic">
+        <div class="music-icon">
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+            <div class="bar"></div>
+        </div>
+        <div class="floating-text" id="floatingText">loading...</div>
+    </div>
+    <audio id="audioPlayer" preload="metadata" style="display:none"></audio>
     <script src="js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add hidden audio elements to non-music pages so tracks continue across navigation
- persist track, time, volume, and play state using localStorage and resume automatically
- make volume slider numeric and default skip buttons to autoplay next track

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688ee2cb625883208feddeec3a7bcefc